### PR TITLE
Improve support for watchify when using the sass preprocessor

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -329,7 +329,7 @@ function compileAsPromise (type, source, lang) {
           source: res,
           type: type
         })
-      })
+      }, compiler)
     })
   } else {
     return Promise.resolve({

--- a/lib/compilers/sass.js
+++ b/lib/compilers/sass.js
@@ -1,6 +1,6 @@
 var options = require('./options')
 
-module.exports = function (raw, cb) {
+module.exports = function (raw, cb, compiler) {
   try {
     var sass = require('node-sass')
   } catch (err) {
@@ -28,6 +28,9 @@ module.exports = function (raw, cb) {
       if (err) {
         cb(err)
       } else {
+        res.stats.includedFiles.forEach(function(file){
+          compiler.emit('dependency', file)
+        })
         cb(null, res.css.toString())
       }
     }


### PR DESCRIPTION
This modification uses the results from the sass compiler to emit
file dependencies for watchify.