### PR TITLE
fix htmlMinifyOptions undefined

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -50,8 +50,10 @@ compiler.loadConfig = function () {
 compiler.applyConfig = function (config) {
   // copy user options to default options
   Object.keys(config).forEach(function (key) {
-    if (key === 'htmlMinifier' && process.env.NODE_ENV === 'production') {
-      htmlMinifyOptions = assign(htmlMinifyOptions, config[key])
+    if (key === 'htmlMinifier') {
+      if (process.env.NODE_ENV === 'production') {
+        htmlMinifyOptions = assign(htmlMinifyOptions, config[key])
+      }
     } else if (key !== 'customCompilers') {
       options[key] = config[key]
     } else {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -50,7 +50,7 @@ compiler.loadConfig = function () {
 compiler.applyConfig = function (config) {
   // copy user options to default options
   Object.keys(config).forEach(function (key) {
-    if (key === 'htmlMinifier') {
+    if (key === 'htmlMinifier' && process.env.NODE_ENV === 'production') {
       htmlMinifyOptions = assign(htmlMinifyOptions, config[key])
     } else if (key !== 'customCompilers') {
       options[key] = config[key]


### PR DESCRIPTION
`htmlMinifyOptions` is `undefined` in development environment.

```
..../node_modules/vueify/lib/compiler.js:53
      htmlMinifyOptions = assign(htmlMinifyOptions, config[key])
                          ^

TypeError: Cannot convert undefined or null to object
```