### PR TITLE
Pass jade options into initial compile, fix #55

### DIFF
--- a/lib/compilers/jade.js
+++ b/lib/compilers/jade.js
@@ -7,7 +7,7 @@ module.exports = function (raw, cb) {
     return cb(err)
   }
   try {
-    var html = jade.compile(raw)(options.jade || {})
+    var html = jade.compile(raw, options.jade || {})()
   } catch (err) {
     return cb(err)
   }


### PR DESCRIPTION
I took a stab at trying to add a test for jade options, but it was a
significant enough change to your test setup that it felt pretty
intrusive.

Thanks for verifying that my fix made sense, and thanks again for your
great work on vue.js.