### PR TITLE
fix htmlMinifier undefined

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,10 +12,10 @@ var chalk = require('chalk')
 var assign = require('object-assign')
 var deindent = require('de-indent')
 var Emitter = require('events').EventEmitter
+var htmlMinifier = require('html-minifier')
 
 // production minifiers
 if (process.env.NODE_ENV === 'production') {
-  var htmlMinifier = require('html-minifier')
   // required for Vue 1.0 shorthand syntax
   var htmlMinifyOptions = {
     customAttrSurround: [[/@/, new RegExp('')], [/:/, new RegExp('')]],


### PR DESCRIPTION
`htmlMinifier` is undefined in production environment.

At `/lib/compiler.js:236`
```
res.source = htmlMinifier.minify(res.source, htmlMinifyOptions)
                          ^ //Cannot read property 'minify' of undefined
```