### PR TITLE
Add parts cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,35 @@
+var crypto = require('crypto')
+
+var Cache = function() {
+	this.cache = {}
+}
+
+Cache.prototype.check = function(key, source) {
+	var cache = this.cache[key],
+		checksum = hash(source)
+
+	if(cache && cache.checksum === checksum) {
+		return false
+	}
+	
+	return checksum
+}
+
+Cache.prototype.get = function(key) {
+	return this.cache[key]
+}
+
+Cache.prototype.set = function(key, checksum, data) {
+	return this.cache[key] = {
+		checksum: checksum,
+		data: data
+	}
+}
+
+function hash(str) {
+	var hash = crypto.createHash('md5')
+	hash.update(str)
+	return hash.digest('hex')
+}
+
+module.exports = new Cache()

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,6 +12,7 @@ var chalk = require('chalk')
 var assign = require('object-assign')
 var deindent = require('de-indent')
 var Emitter = require('events').EventEmitter
+var cache = require('./cache')
 
 var htmlMinifyOptions = {
   collapseWhitespace: true,
@@ -203,11 +204,17 @@ function isScoped (node) {
 
 function processTemplate (node, filePath, id, hasScopedStyle, fullSource) {
   var lang = checkLang(node)
+  var key = filePath + ':template'
   var template = checkSrc(node, filePath) || (
     lang
       ? getRawTemplate(node, fullSource) // custom template, extract as raw string
       : parse5.serialize(node.content) // normal HTML, use serialization
   )
+  var checksum = cache.check(key, template)
+  if (!checksum) {
+    return cache.get(key).data
+  }
+
   template = deindent(template)
   if (!lang) {
     var warnings = validateTemplate(node.content, fullSource)
@@ -230,6 +237,7 @@ function processTemplate (node, filePath, id, hasScopedStyle, fullSource) {
       if (process.env.NODE_ENV === 'production') {
         res.source = require('html-minifier').minify(res.source, htmlMinifyOptions)
       }
+      cache.set(key, checksum, res)
       return res
     })
 }
@@ -265,10 +273,21 @@ function getRawTemplate (node, source) {
 function processStyle (node, filePath, id) {
   var style = checkSrc(node, filePath) || parse5.serialize(node)
   var lang = checkLang(node)
+  var key = filePath + ':style'
+  var checksum = cache.check(key, style)
+
+  if (!checksum) {
+    return cache.get(key).data
+  }
+  
   style = deindent(style)
   return compileAsPromise('style', style, lang, filePath)
     .then(function (res) {
       return rewriteStyle(id, res.source, isScoped(node))
+    })
+    .then(function (data) {
+      cache.set(key, checksum, data)
+      return data
     })
 }
 
@@ -284,6 +303,8 @@ function processStyle (node, filePath, id) {
 function processScript (node, filePath, content) {
   var lang = checkLang(node) || 'babel'
   var script = checkSrc(node, filePath)
+  var key = filePath + ':script'
+  
   if (!script) {
     script = parse5.serialize(node)
     // pad the script to ensure correct line number for syntax errors
@@ -291,8 +312,20 @@ function processScript (node, filePath, content) {
     var before = padContent(content.slice(0, location))
     script = before + script
   }
+
+  script = script.trimLeft()
+  var checksum = cache.check(key, script)
+  
+  if (!checksum) {
+    return cache.get(key).data
+  }
+
   script = deindent(script)
   return compileAsPromise('script', script, lang, filePath)
+    .then(function(data) {
+      cache.set(key, checksum, data)
+      return data
+    })
 }
 
 /**


### PR DESCRIPTION
Hey, wrote simple parts cache. Calculating checksum should be faster than compiling whole .vue file on part change. What you think about?

I'm trying to catch script change only and force reload page (for templates and styles i use browserify-hmr).