### PR TITLE
Add pug support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ These are the built-in preprocessors:
 - less
 - scss (via `node-sass`)
 - jade
+- pug
 - coffee-script
 
 ## Autoprefix by Default

--- a/lib/compilers/index.js
+++ b/lib/compilers/index.js
@@ -6,5 +6,6 @@ module.exports = {
   sass: require('./sass'),
   scss: require('./sass'),
   stylus: require('./stylus'),
-  jade: require('./jade')
+  jade: require('./jade'),
+  pug: require('./pug')
 }

--- a/lib/compilers/pug.js
+++ b/lib/compilers/pug.js
@@ -1,0 +1,15 @@
+var options = require('./options')
+
+module.exports = function (raw, cb) {
+  try {
+    var pug = require('pug')
+  } catch (err) {
+    return cb(err)
+  }
+  try {
+    var html = pug.compile(raw, options.pug || {})()
+  } catch (err) {
+    return cb(err)
+  }
+  cb(null, html)
+}

--- a/package.json
+++ b/package.json
@@ -45,17 +45,18 @@
     "vue-hot-reload-api": "^1.2.0"
   },
   "devDependencies": {
+    "babel-core": "^6.1.2",
+    "babel-plugin-transform-runtime": "^6.1.2",
+    "babel-preset-es2015": "^6.1.2",
+    "babel-runtime": "^5.8.0",
     "coffee-script": "^1.10.0",
     "jade": "^1.11.0",
     "less": "^2.5.1",
     "mocha": "^2.3.3",
     "node-sass": "^3.3.3",
+    "pug": "^2.0.0-alpha6",
     "stylus": "^0.52.4",
-    "vueify-insert-css": "^1.0.0",
-    "babel-core": "^6.1.2",
-    "babel-runtime": "^5.8.0",
-    "babel-preset-es2015": "^6.1.2",
-    "babel-plugin-transform-runtime": "^6.1.2",
-    "vue-hot-reload-api": "^1.2.0"
+    "vue-hot-reload-api": "^1.2.0",
+    "vueify-insert-css": "^1.0.0"
   }
 }

--- a/test/expects/pug.js
+++ b/test/expects/pug.js
@@ -1,0 +1,1 @@
+;(typeof module.exports === "function"? module.exports.options: module.exports).template = "<ul><li>foo<li>bar<li>baz</ul><ul><li>foo<li>bar<li>baz</ul>"

--- a/test/fixtures/pug.vue
+++ b/test/fixtures/pug.vue
@@ -1,0 +1,11 @@
+<template lang="pug">
+//- Declaration
+mixin list
+  ul
+    li foo
+    li bar
+    li baz
+//- Use
++list
++list
+</template>


### PR DESCRIPTION
Per https://github.com/pugjs/pug/issues/2184, Jade was renamed to Pug.

This does not remove the jade pre-processing files. 

Closes #79