### PR TITLE
marko-support

### DIFF
--- a/lib/compilers/index.js
+++ b/lib/compilers/index.js
@@ -7,5 +7,6 @@ module.exports = {
   scss: require('./sass'),
   stylus: require('./stylus'),
   jade: require('./jade'),
-  pug: require('./pug')
+  pug: require('./pug'),
+  marko: require('./marko')
 }

--- a/lib/compilers/marko.js
+++ b/lib/compilers/marko.js
@@ -1,0 +1,20 @@
+var options = require('./options')
+var ensureRequire = require('../ensure-require.js')
+
+module.exports = function (raw, cb) {
+  ensureRequire('marko','marko')
+  var marko = require('marko')
+  var helpers = marko.helpers
+  var templatePath = 'dummy.marko'
+  var html
+  try {
+    var template = marko.load(templatePath, raw, {buffer: false})
+    var rendered = template.render({})
+
+    html = rendered.writer.str
+    console.log(html)
+  } catch (err) {
+    return cb(err)
+  }
+  cb(null, html)
+}

--- a/lib/compilers/marko.js
+++ b/lib/compilers/marko.js
@@ -4,15 +4,10 @@ var ensureRequire = require('../ensure-require.js')
 module.exports = function (raw, cb) {
   ensureRequire('marko','marko')
   var marko = require('marko')
-  var helpers = marko.helpers
-  var templatePath = 'dummy.marko'
-  var html
   try {
-    var template = marko.load(templatePath, raw, {buffer: false})
+    var template = marko.load('dummy.marko', raw, {buffer: false})
     var rendered = template.render({})
-
-    html = rendered.writer.str
-    console.log(html)
+    var html = rendered.writer.str
   } catch (err) {
     return cb(err)
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "coffee-script": "^1.10.0",
     "jade": "^1.11.0",
     "less": "^2.5.1",
+    "marko": "^3.4.4",
     "mocha": "^2.3.3",
     "node-sass": "^3.3.3",
     "pug": "^2.0.0-alpha6",

--- a/test/expects/marko.js
+++ b/test/expects/marko.js
@@ -1,0 +1,1 @@
+;(typeof module.exports === "function"? module.exports.options: module.exports).template = "<div class=greeting style=\"background-color: green\">Hello World!</div><div class=greeting style=\"background-color: yellow\">Hello Frank!</div>"

--- a/test/fixtures/marko.vue
+++ b/test/fixtures/marko.vue
@@ -1,0 +1,7 @@
+<template lang="marko">
+macro greeting(name,color)
+  div class="greeting" style="background-color: ${color}"
+    - Hello ${name}!
+greeting name="World" color="green"
+greeting('Frank', 'yellow')
+</template>


### PR DESCRIPTION
I've added support for [marko](http://markojs.com/docs/), another templating engine which is comparable with jade/pug, but is has moer feature, supporting `html`-like syntax, and a concise syntax like pug, or a mix of both.

An online demo of marko is [here](http://markojs.com/try-online/).