### PR TITLE
Don't make .babelrc a requirement.

### DIFF
--- a/lib/compilers/babel.js
+++ b/lib/compilers/babel.js
@@ -3,27 +3,27 @@ var path = require('path')
 var assign = require('object-assign')
 var ensureRequire = require('../ensure-require')
 
+var defaultBabelOptions = {
+  presets: ['es2015'],
+  plugins: ['transform-runtime']
+}
+
+var babelRcPath = path.resolve(process.cwd(), '.babelrc')
+var babelOptions = fs.existsSync(babelRcPath)
+  ? getBabelRc() || defaultBabelOptions
+  : defaultBabelOptions
+
+function getBabelRc () {
+  var rc
+  try {
+    rc = JSON.parse(fs.readFileSync(babelRcPath, 'utf-8'))
+  } catch (e) {
+    throw new Error('[vueify] Your .babelrc seems to be incorrectly formatted.')
+  }
+  return rc
+}
+
 module.exports = function (raw, cb, compiler, filePath) {
-  var defaultBabelOptions = {
-    presets: ['es2015'],
-    plugins: ['transform-runtime']
-  }
-
-  var babelRcPath = path.resolve(process.cwd(), '.babelrc')
-  var babelOptions = fs.existsSync(babelRcPath)
-    ? getBabelRc() || defaultBabelOptions
-    : defaultBabelOptions
-
-  function getBabelRc () {
-    var rc
-    try {
-      rc = JSON.parse(fs.readFileSync(babelRcPath, 'utf-8'))
-    } catch (e) {
-      throw new Error('[vueify] Your .babelrc seems to be incorrectly formatted.')
-    }
-    return rc
-  }
-
   if (babelOptions === defaultBabelOptions) {
     try {
       ensureRequire('babel', ['babel-preset-es2015', 'babel-runtime', 'babel-plugin-transform-runtime'])

--- a/lib/compilers/babel.js
+++ b/lib/compilers/babel.js
@@ -3,40 +3,40 @@ var path = require('path')
 var assign = require('object-assign')
 var ensureRequire = require('../ensure-require')
 
-var defaultBabelOptions = {
-  presets: ['es2015'],
-  plugins: ['transform-runtime']
-}
-
-var babelRcPath = path.resolve(process.cwd(), '.babelrc')
-var babelOptions = fs.existsSync(babelRcPath)
-  ? getBabelRc() || defaultBabelOptions
-  : defaultBabelOptions
-
-function getBabelRc () {
-  var rc
-  try {
-    rc = JSON.parse(fs.readFileSync(babelRcPath, 'utf-8'))
-  } catch (e) {
-    throw new Error('[vueify] Your .babelrc seems to be incorrectly formatted.')
-  }
-  return rc
-}
-
-if (babelOptions === defaultBabelOptions) {
-  try {
-    ensureRequire('babel', ['babel-preset-es2015', 'babel-runtime', 'babel-plugin-transform-runtime'])
-  } catch (e) {
-    console.error(e.message)
-    console.error(
-      '\n^^^ You are seeing this because you are using Vueify\'s default babel ' +
-      'configuration. You can override this with .babelrc or the babel option ' +
-      'in vue.config.js.'
-    )
-  }
-}
-
 module.exports = function (raw, cb, compiler, filePath) {
+  var defaultBabelOptions = {
+    presets: ['es2015'],
+    plugins: ['transform-runtime']
+  }
+
+  var babelRcPath = path.resolve(process.cwd(), '.babelrc')
+  var babelOptions = fs.existsSync(babelRcPath)
+    ? getBabelRc() || defaultBabelOptions
+    : defaultBabelOptions
+
+  function getBabelRc () {
+    var rc
+    try {
+      rc = JSON.parse(fs.readFileSync(babelRcPath, 'utf-8'))
+    } catch (e) {
+      throw new Error('[vueify] Your .babelrc seems to be incorrectly formatted.')
+    }
+    return rc
+  }
+
+  if (babelOptions === defaultBabelOptions) {
+    try {
+      ensureRequire('babel', ['babel-preset-es2015', 'babel-runtime', 'babel-plugin-transform-runtime'])
+    } catch (e) {
+      console.error(e.message)
+      console.error(
+        '\n^^^ You are seeing this because you are using Vueify\'s default babel ' +
+        'configuration. You can override this with .babelrc or the babel option ' +
+        'in vue.config.js.'
+      )
+    }
+  }
+
   try {
     var babel = require('babel-core')
     var options = assign({


### PR DESCRIPTION
If you don't have a .babelrc file in your project you still get babel warning: "You are trying to use "babel". babel-preset-es2015, babel-runtime and babel-plugin-transform-runtime are missing."