### PR TITLE
babel is only one option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install vueify --save-dev
 browserify -t vueify -e src/main.js -o build/build.js
 ```
 
-If you are using npm 3+, it no longer auto install the peer dependencies. So you will also have to also install the babel-related dependencies:
+If you are using npm 3+ and **babel**, it no longer auto install the peer dependencies. So you will also have to also install the babel-related dependencies:
 
 ``` bash
 npm install\

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Make sure to have the `NODE_ENV` environment variable set to `"production"` when
 
 If you are using Gulp, note that `gulp --production` **does not** affect vueify; you still need to explicitly set `NODE_ENV=production`.
 
-## ES2015 by Default
+## ES2015 when `babel-core` installed
 
-Vueify automatically transforms the JavaScript in your `*.vue` components using Babel. Write ES2015 today!
+Vueify automatically transforms the JavaScript in your `*.vue` components using Babel when it is installed. Write ES2015 today!
 
 The default Babel (6) options used for Vue.js components are:
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -22,6 +22,13 @@ try {
   hotReloadAPIPath = 'vueify/node_modules/vue-hot-reload-api'
 }
 
+var hasBabel = true
+try {
+  require('babel-core')
+} catch (e) {
+  hasBabel = false
+}
+
 var htmlMinifyOptions = {
   collapseWhitespace: true,
   removeComments: true,
@@ -291,7 +298,8 @@ function processStyle (node, filePath, id) {
  */
 
 function processScript (node, filePath, content) {
-  var lang = checkLang(node) || 'babel'
+  var lang = checkLang(node) || (hasBabel ? 'babel' : null)
+
   var script = checkSrc(node, filePath)
   if (!script) {
     script = parse5.serialize(node)


### PR DESCRIPTION
Still default if installed.

No need to install any of

- `babel-core`
- `babel-preset-es2015`
- `babel-plugin-transform-runtime`
- `babel-runtime`

Ref: https://github.com/vuejs/vueify/issues/95