### PR TITLE
Fix the bug "failing to update when using browserify"

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -156,7 +156,7 @@ compiler.compile = function (content, filePath, cb) {
         '  hotAPI.install(require("vue"), true)\n' +
         '  if (!hotAPI.compatible) return\n' +
         // remove style tag on dispose
-        (style && 'object' === typeof(__vueify_style__) && __vueify_style__ instanceof Node
+        ((style && 'object' === typeof(__vueify_style__) && __vueify_style__ instanceof Node)
           ? '  module.hot.dispose(function () {\n' +
             '    __vueify_insert__.cache[' + style + '] = false\n' +
             '    document.head.removeChild(__vueify_style__)\n' +

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -156,7 +156,7 @@ compiler.compile = function (content, filePath, cb) {
         '  hotAPI.install(require("vue"), true)\n' +
         '  if (!hotAPI.compatible) return\n' +
         // remove style tag on dispose
-        (style
+        (style && 'object' === typeof(__vueify_style__) && __vueify_style__ instanceof Node
           ? '  module.hot.dispose(function () {\n' +
             '    __vueify_insert__.cache[' + style + '] = false\n' +
             '    document.head.removeChild(__vueify_style__)\n' +


### PR DESCRIPTION
I encounter this problem when using browserify

[HMR] Error applying update TypeError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'. [see here](https://github.com/AgentME/browserify-hmr/issues/27)

I found that it relates to `__vueify_style__`.

so I add a type-check before disposing