### PR TITLE
Updating template location for vueify example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ npm install browserify-hmr --save-dev
 watchify -p browserify-hmr index.js -o bundle.js
 ```
 
-You can scaffold a hot-reload enabled project easily using `vue-cli` and the [this template](https://github.com/vuejs-templates/browserify-simple-2.0).
+You can scaffold a hot-reload enabled project easily using `vue-cli` and the [this template](https://github.com/vuejs-templates/browserify).
 
 ## CSS Extraction
 


### PR DESCRIPTION
The old link to the vueify example is now a 404. Replaced it with the current example.
