### PR TITLE
Load configuration from vue.config.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = function vueify (file, options) {
     return through()
   }
 
+  compiler.loadConfig()
   compiler.applyConfig(options)
   compiler.applyConfig({
     sourceMap: options._flags.debug


### PR DESCRIPTION
Resolves #116 and #145

It appears `vue.config.js` simply wasn't getting loaded. This fixes it.
