### PR TITLE
Fix errors with scoped modules

### DIFF
--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -40,7 +40,7 @@ var addId = postcss.plugin('add-id', function () {
  */
 
 module.exports = function (id, css, scoped, options) {
-  var key = id + '!!' + css
+  var key = id + '!!' + scoped + '!!' + css
   var val = cache.get(key)
   if (val) {
     return Promise.resolve(val)
@@ -56,9 +56,16 @@ module.exports = function (id, css, scoped, options) {
     }
 
     // scoped css rewrite
-    if (scoped) {
+    // make sure the addId plugin is only pushed once
+    if (scoped && plugins.indexOf(addId) === -1) {
       plugins.push(addId)
     }
+
+    // remove the addId plugin if the style block is not scoped
+    if (!scoped && plugins.indexOf(addId) !== -1) {
+      plugins.splice(plugins.indexOf(addId), 1)
+    }
+
     // minification
     if (process.env.NODE_ENV === 'production') {
       plugins.push(require('cssnano')(assign({


### PR DESCRIPTION
I noticed some problems with the scoped modules, especially when using [Watchify](https://github.com/substack/watchify) and the `extract-css` plugin.

These bugs do not occur when restarting Browserify before every render, but get really annoying when using Watchify and keeping the program state around. 

There were two bugs that his Pull Request addresses:

1. When changing nothing except the `scoped` attribute on a `<style>` tag, the CSS would not get updated. This is because the value of `scoped` wasn't part of the cache `key`. I fixed that by simply adding the `scoped` variable to the key.

2. When Watchify did another bundling, the `addId` PostCSS plugin from `lib/style-rewriter.js` got added another time, but didn't get removed if the component was not `scoped`. This led to multiple `[data-v-x]` ids on selectors as well as ids on selectors that shouldn't even be scoped. For example:

```
.Menu[data-v-3][data-v-3][data-v-3] {
  display: flex;
}
```

I fixed that by ensuring the `plugins` array only has a maximum of 1 `addId` function, and by removing the function if the component is not scoped.
