### PR TITLE
Remove listener that's leading to memory leak

### DIFF
--- a/plugins/extract-css.js
+++ b/plugins/extract-css.js
@@ -23,16 +23,11 @@ module.exports = function (b, opts) {
     })
   })
 
-  b.on('reset', listen)
-  listen()
-
-  function listen () {
-    b.on('transform', function (tr, file) {
-      if (tr.vueify) {
-        tr.on('vueify-style', function (e) {
-          styles[e.file] = e.style
-        })
-      }
-    })
-  }
+  b.on('transform', function (tr, file) {
+    if (tr.vueify) {
+      tr.on('vueify-style', function (e) {
+        styles[e.file] = e.style
+      })
+    }
+  })
 }


### PR DESCRIPTION
By calling `listen` on every `reset` event, the `transform` listener is attached multiple times.

I'm actually not even really sure what the `reset` event signifies. In my tests, everything seems to work fine without it.

If this is not a good solution, it would still be nice to fix the leak.