### PR TITLE
Parse babelrc with json5

### DIFF
--- a/lib/compilers/babel.js
+++ b/lib/compilers/babel.js
@@ -1,5 +1,6 @@
 var fs = require('fs')
 var path = require('path')
+var json = require('json5')
 var assign = require('object-assign')
 var ensureRequire = require('../ensure-require')
 
@@ -16,7 +17,7 @@ var babelOptions = fs.existsSync(babelRcPath)
 function getBabelRc () {
   var rc
   try {
-    rc = JSON.parse(fs.readFileSync(babelRcPath, 'utf-8'))
+    rc = json.parse(fs.readFileSync(babelRcPath, 'utf-8'))
   } catch (e) {
     throw new Error('[vueify] Your .babelrc seems to be incorrectly formatted.')
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "postcss-selector-parser": "^2.0.0",
     "source-map": "^0.5.6",
     "through": "^2.3.6",
+    "json5": "^0.5.1",
     "vue-hot-reload-api": "^2.0.1",
     "vue-template-compiler": "^2.0.0-alpha.8",
     "vue-template-es2015-compiler": "^1.2.2"


### PR DESCRIPTION
Babel parse .babelrc with json5, and I think we should respect it here.