### PR TITLE
Fixed Node deprecated warning

### DIFF
--- a/plugins/extract-css.js
+++ b/plugins/extract-css.js
@@ -18,7 +18,7 @@ module.exports = function (b, opts) {
         outPath.write(css)
         outPath.end()
       } else if (typeof outPath === 'string') {
-        fs.writeFile(outPath, css)
+        fs.writeFile(outPath, css, function () {})
       }
     })
   })


### PR DESCRIPTION
Suppresses "DeprecationWarning: Calling an asynchronous function without callback is deprecated."