### PR TITLE
Added callback support to plugins/extract-css

### DIFF
--- a/plugins/extract-css.js
+++ b/plugins/extract-css.js
@@ -7,18 +7,26 @@ module.exports = function (b, opts) {
   })
 
   var styles = Object.create(null)
-  var outPath = opts.out || opts.o || 'bundle.css'
+  var outCallback = opts.callback || opts.c || false
+  var outPath = opts.out || opts.o || (outCallback ? undefined : 'bundle.css')
 
   b.on('bundle', function (bs) {
     bs.on('end', function () {
       var css = Object.keys(styles)
         .map(function (file) { return styles[file] })
         .join('\n')
+      var callback = function () {
+        if(typeof outCallback === 'function') {
+          outCallback(css)
+        }
+      }
+
       if (typeof outPath === 'object' && outPath.write) {
-        outPath.write(css)
-        outPath.end()
+        outPath.end(css, callback)
       } else if (typeof outPath === 'string') {
-        fs.writeFile(outPath, css, function () {})
+        fs.writeFile(outPath, css, callback)
+      } else {
+        callback()
       }
     })
   })


### PR DESCRIPTION
I've added a callback option so that you can append the extracted css to a gulp stream or whatever you'd like.

I personally make use of this in combination with [gulp-inject-string](https://www.npmjs.com/package/gulp-inject-string), allowing me to append the extracted css to the rest of my css and run it through gulp. This way, I can prefix and minify all of my css (including the extracted css!) into one file that gets served to users.