### PR TITLE
Prevent crash when options._flags is undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function vueify (file, options) {
   compiler.loadConfig()
   compiler.applyConfig(options)
   compiler.applyConfig({
-    sourceMap: options._flags.debug
+    sourceMap: !!options._flags && options._flags.debug
   })
 
   var data = ''


### PR DESCRIPTION
Some tools might pass an empty options object to Vueify. This means options._flags is undefined, and options._flags.debug is a crash.
Short-circuiting falsey _flags values will prevent this crash in most cases.