### PR TITLE
Fixes #138 Fixes #162 Optionally apply config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,12 @@ module.exports = function vueify (file, options) {
 
   compiler.loadConfig()
   compiler.applyConfig(options)
-  compiler.applyConfig({
-    sourceMap: options._flags.debug
-  })
+
+  if (options._flags) {
+    compiler.applyConfig({
+      sourceMap: options._flags.debug
+    })
+  }
 
   var data = ''
   var stream = through(write, end)


### PR DESCRIPTION
options._flags is not always set when using browserify transformations

- version affected: "vueify": "^9.4.0"

Example of failure in gulp file

```javascript
// gulpfile.js
gulp.task('all', function() {
    process.env.NODE_ENV = 'production';
    return browserify('./source/js/all.js')
        .transform(babelify.configure({ presets: ["es2015"]}))
        .transform(vueify)
        .bundle()
        .pipe(source('./js/all.js'))
        .pipe(buffer())
        .pipe(rev())
        .pipe(gulp.dest(pub))
        .pipe(rev.manifest('./build/rev-manifest.json', {
          base: '',
          merge: true
        }))
        .pipe(gulp.dest('.'));
});

```

```bash
$ gulp all

[19:15:56] Using gulpfile ~/gulpfile.js
[19:15:56] Starting 'all'...
code/node_modules/vueify/index.js:12
    sourceMap: options._flags.debug
                             ^

TypeError: Cannot read property 'debug' of undefined
    at vueify (code/node_modules/vueify/index.js:12:30)

```