### PR TITLE
Add locals object in pug render function

### DIFF
--- a/lib/compilers/pug.js
+++ b/lib/compilers/pug.js
@@ -2,9 +2,14 @@ var ensureRequire = require('../ensure-require.js')
 
 module.exports = function (raw, cb, compiler) {
   ensureRequire('pug', 'pug')
-  var pug = require('pug')
+  var pug = require('pug'),
+    locals,
+    options = compiler.options.pug || {};
+
+  locals = options.data || {};
+
   try {
-    var html = pug.compile(raw, compiler.options.pug || {})()
+    var html = pug.compile(raw, options)(locals)
   } catch (err) {
     return cb(err)
   }


### PR DESCRIPTION
This PR is going to solve this issue: https://github.com/vuejs/vueify/issues/181
Now it's possible to define variables in vueify config to be used inside a pug template:

``` javascript
// vue.config.js
module.exports = {
  pug: {
    basedir: __dirname,
    data: {
      imageBasePath: 'https://example.com/'
    }
  }
};
```