### PR TITLE
Fix: invalid warning about babel

### DIFF
--- a/lib/compilers/babel.js
+++ b/lib/compilers/babel.js
@@ -25,7 +25,7 @@ function getBabelRc () {
 }
 
 module.exports = function (raw, cb, compiler, filePath) {
-  if (babelOptions === defaultBabelOptions) {
+  if ((compiler.options.babel || babelOptions) === defaultBabelOptions) {
     try {
       ensureRequire('babel', ['babel-preset-es2015', 'babel-runtime', 'babel-plugin-transform-runtime'])
     } catch (e) {


### PR DESCRIPTION
In the following code and no `.babelrc`, `vueify` prints an error message wrongly based on unused default options. This PR fixes the problem.

```js
browserify(entryFile)
    .transform("vueify", { babel: { /* some settings */ } })
    .bundle()
    .pipe(output)
```

```
You are trying to use "babel". babel-preset-es2015 and babel-plugin-transform-runtime is missing.

To install run:
npm install --save-dev babel-preset-es2015 babel-plugin-transform-runtime

^^^ You are seeing this because you are using Vueify's default babel configuration. You can override this with .babelrc or the babel option in vue.config.js.
```

This PR related to the line [/lib/compilers/babel.js#L47](https://github.com/vuejs/vueify/blob/80e168ae34f9feee2eca5d76e386681442710753/lib/compilers/babel.js#L47).