### PR TITLE
Add option to disable postcss

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -264,6 +264,12 @@ function processStyle (part, filePath, id, parts) {
   return compileAsPromise('style', style, part.lang, filePath)
     .then(function (res) {
       res = res.trim()
+    
+      if (options.disablePostcss) {
+        parts.styles.push(style);
+        return;
+      }
+          
       return rewriteStyle(id, res, part.scoped, options).then(function (res) {
         parts.styles.push(res)
       })


### PR DESCRIPTION
When extracting the pure sass content via the extract-css module, it crashes when using string interpolation expressions, i.e.
#{$textInputSelector} {}
It would be nice, if one was able to disable postcss completely.