### PR TITLE
Change all occurrences of "coffee-script" with "coffeescript"

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These are the preprocessors supported by vueify out of the box:
 - scss (via `node-sass`, use `sass` in [config section](#configuring-options))
 - jade
 - pug
-- coffee-script (use `coffee` in [config section](#configuring-options))
+- coffeescript (use `coffee` in [config section](#configuring-options))
 
 ## PostCSS
 

--- a/lib/compilers/coffee.js
+++ b/lib/compilers/coffee.js
@@ -1,8 +1,8 @@
 var ensureRequire = require('../ensure-require.js')
 
 module.exports = function (raw, cb, compiler) {
-  ensureRequire('coffee', ['coffee-script'])
-  var coffee = require('coffee-script')
+  ensureRequire('coffee', ['coffeescript'])
+  var coffee = require('coffeescript')
   var compiled
   try {
     compiled = coffee.compile(raw, compiler.options.coffee || {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-runtime": "^6.0.0",
     "browserify": "^13.0.1",
     "chai": "^3.5.0",
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^1.10.0",
     "eslint": "^2.13.0",
     "eslint-config-vue": "^1.0.3",
     "eslint-plugin-html": "^1.5.3",


### PR DESCRIPTION
- Prepares for future versions of coffeescript, e.g. 2.x

From Coffeescript ^12.6, coffee-script is also being published as "coffeescript" on npm. 
(https://github.com/jashkenas/coffeescript/pull/4548/commits/8ec10fa8ce9138db220844af31d9826660660513)
They published all versions back to 0.7.0 under "coffeescript"
`npm view coffeescript`
Coffeescript 2.x and future versions are/will only be published under "coffeescript" and "coffee-script" will stay with version 1.x forever.