### PR TITLE
Use synchronous version of writeFile in extract-css

### DIFF
--- a/plugins/extract-css.js
+++ b/plugins/extract-css.js
@@ -18,7 +18,7 @@ module.exports = function (b, opts) {
         outPath.write(css)
         outPath.end()
       } else if (typeof outPath === 'string') {
-        fs.writeFile(outPath, css, function () {})
+        fs.writeFileSync(outPath, css)
       }
     })
   })


### PR DESCRIPTION
We are never waiting for async writeFile to complete. This can sometimes result in empty file.