### PR TITLE
Add support for babel options via browserify cli

### DIFF
--- a/lib/compilers/babel.js
+++ b/lib/compilers/babel.js
@@ -40,6 +40,18 @@ module.exports = function (raw, cb, compiler, filePath) {
 
   try {
     var babel = require('babel-core')
+
+    // browserify cli options
+    var opts = compiler.options.babel
+    if (opts) {
+      delete opts._
+      // "--opt [ a b ]" and "--opt a --opt b" are allowed:
+      if (opts.ignore && opts.ignore._) opts.ignore = opts.ignore._
+      if (opts.only && opts.only._) opts.only = opts.only._
+      if (opts.plugins && opts.plugins._) opts.plugins = opts.plugins._
+      if (opts.presets && opts.presets._) opts.presets = opts.presets._
+    }
+
     var options = assign({
       comments: false,
       filename: filePath,


### PR DESCRIPTION
Add support for setting for example babel presets using browserify cli:
browserify -t [ vueify --babel [ --presets [ env ] ] ] -e main.js -o build.js