### PR TITLE
Pug: relative include/extends in templates

### DIFF
--- a/lib/compilers/pug.js
+++ b/lib/compilers/pug.js
@@ -1,10 +1,16 @@
 var ensureRequire = require('../ensure-require.js')
 
-module.exports = function (raw, cb, compiler) {
+module.exports = function (raw, cb, compiler, filePath) {
   ensureRequire('pug', 'pug')
   var pug = require('pug')
   try {
-    var html = pug.compile(raw, compiler.options.pug || {})()
+    var defaultOptions = {
+      filename: filePath
+    }
+    var html = pug.compile(
+      raw,
+      Object.assign({}, compiler.options.pug || {}, defaultOptions)
+    )()
   } catch (err) {
     return cb(err)
   }

--- a/test/fixtures/pug-included.pug
+++ b/test/fixtures/pug-included.pug
@@ -1,0 +1,1 @@
+div Included content

--- a/test/fixtures/pug.vue
+++ b/test/fixtures/pug.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
 div
   h1 This is the app
+  include ./pug-included
   comp-a
   comp-b
 </template>

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,7 @@ describe('vueify', () => {
     assertRenderFn(module,
       '<div>' +
         '<h1>This is the app</h1>' +
+        '<div>Included content</div>' +
         '<comp-a></comp-a>' +
         '<comp-b></comp-b>' +
       '</div>'


### PR DESCRIPTION
Using the `include`/`exclude` keywords inside of pug `<template>`'s as following:
```vue
<!-- component.vue -->
<template lang="pug">
div
  h1 This is the app
  include ./pug-included
  comp-a
  comp-b
</template>
```

```pug
// pug-included.pug
div Included content
```

...did not work before, as you ought to provide the `filename` option to pug's `.compile()` method to use those features.